### PR TITLE
fix: race condition causing tasks to be rejected

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -1109,6 +1109,12 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                 if (executors.containsKey(executorHolder.info.getName())) {
                     throw new IllegalStateException("duplicate executors with name [" + executorHolder.info.getName() + "] registered");
                 }
+                if (executorHolder.executor() instanceof EsThreadPoolExecutor) {
+                    // tell the original executor about the new one, to direct tasks after shutdown to the new holder
+                    ((EsThreadPoolExecutor) executor(entry.getKey())).signalThreadPoolReconfiguration(
+                        (EsThreadPoolExecutor) executorHolder.executor()
+                    );
+                }
                 logger.debug("created NEW thread pool: {}", entry.getValue().formatInfo(executorHolder.info));
                 executors.put(entry.getKey(), executorHolder);
             }


### PR DESCRIPTION
Some flows included a method obtaining the `executor` instance from the `ThreadPool` class object and then passing it to another method which would schedule tasks on it. In the meanwhile the specific `executor` could have been shut down due to thread pool reconfiguration, thus leading to tasks being rejected because the `executor` was in the `SHUTDOWN` or `TERMINATED` state.

This PR fixes this issue by signalling older thread pools about the respective new thread pools (just) before being shutdown so that they redirect tasks to the new thread pools afterwards.
