### PR TITLE
feat: carry forward statistics from terminated thread pool executors

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -81,6 +82,25 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
                     listener = null;
                 }
             }
+        }
+        // send thread pool statistics for future use
+        RejectedExecutionHandler handler = getRejectedExecutionHandler();
+        final String[] nameParts = name.split("/");
+        if (handler instanceof EsRejectedExecutionHandler) {
+            ThreadPool.storeOriginalThreadPoolCarryForwardStatistics(
+                // name of the thread pool without the node name part
+                nameParts[nameParts.length - 1],
+                getLargestPoolSize(),
+                getCompletedTaskCount(),
+                ((EsRejectedExecutionHandler) handler).rejected()
+            );
+        } else {
+            ThreadPool.storeOriginalThreadPoolCarryForwardStatistics(
+                // name of the thread pool without the node name part
+                nameParts[nameParts.length - 1],
+                getLargestPoolSize(),
+                getCompletedTaskCount()
+            );
         }
     }
 


### PR DESCRIPTION
Thread pool statistics are handled by the native ThreadPoolExecutor class. When thread pools are reconfigured and the older ones are shutdown, these are lost.
This PR fixes this by having executors sending statistics that can be carried forward to the ThreadPool class and then aggregating them with the current thread pool executor stats when stats are required
