### PR TITLE
feat: (optionally) configure specific nodes' thread pools

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reconfigure_thread_pools/ThreadPoolConfigurationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reconfigure_thread_pools/ThreadPoolConfigurationRequest.java
@@ -1,7 +1,6 @@
 package org.elasticsearch.action.admin.cluster.node.reconfigure_thread_pools;
 
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -14,10 +13,10 @@ public class ThreadPoolConfigurationRequest extends BaseNodesRequest<ThreadPoolC
     }
 
     /**
-     * Default constructor, to signal reconfiguration of thread pools of all nodes
+     * Reconfigure specified nodes
      */
-    public ThreadPoolConfigurationRequest() {
-        super(Strings.tokenizeToStringArray("_all", ","));
+    public ThreadPoolConfigurationRequest(String... nodesIds) {
+        super(nodesIds);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestThreadPoolConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestThreadPoolConfigurationAction.java
@@ -10,18 +10,24 @@ package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.action.admin.cluster.node.reconfigure_thread_pools.ThreadPoolConfigurationRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.rest.action.RestActions.NodesResponseRestListener;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestThreadPoolConfigurationAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
-        return Collections.singletonList(new Route(RestRequest.Method.GET, "/_nodes/reconfigure_thread_pools"));
+        return unmodifiableList(
+            asList(new Route(GET, "/_nodes/reconfigure_thread_pools"), new Route(GET, "/_nodes/reconfigure_thread_pools/{nodeId}"))
+        );
     }
 
     @Override
@@ -31,9 +37,14 @@ public class RestThreadPoolConfigurationAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final ThreadPoolConfigurationRequest threadPoolConfigurationRequest = new ThreadPoolConfigurationRequest();
+        final ThreadPoolConfigurationRequest threadPoolConfigurationRequest = prepareRequest(request);
         return channel -> client.admin()
             .cluster()
-            .updateNodesThreadPools(threadPoolConfigurationRequest, new RestActions.NodesResponseRestListener<>(channel));
+            .updateNodesThreadPools(threadPoolConfigurationRequest, new NodesResponseRestListener<>(channel));
+    }
+
+    static ThreadPoolConfigurationRequest prepareRequest(final RestRequest request) {
+        final String[] nodeIds = Strings.tokenizeToStringArray(request.param("nodeId", "_all"), ",");
+        return new ThreadPoolConfigurationRequest(nodeIds);
     }
 }


### PR DESCRIPTION
This PR contains code to reconfigure thread pools of select nodes by specifying their node IDs (as in other existing APIs like the node info API)